### PR TITLE
refactor x3d

### DIFF
--- a/pytorchvideo/layers/swish.py
+++ b/pytorchvideo/layers/swish.py
@@ -9,8 +9,10 @@ class Swish(nn.Module):
     Wrapper for the Swish activation function.
     """
 
+    # def forward(self, x):
+    #     return SwishFunction.apply(x)
     def forward(self, x):
-        return SwishFunction.apply(x)
+        return x * torch.sigmoid(x)
 
 
 class SwishFunction(torch.autograd.Function):

--- a/pytorchvideo/models/x3d.py
+++ b/pytorchvideo/models/x3d.py
@@ -523,7 +523,7 @@ def create_x3d_head(
         )
 
     if output_with_global_average:
-        output_pool = nn.AdaptiveAvgPool3d(1)
+        output_pool = nn.AvgPool3d(kernel_size=(4, 6, 6))
     else:
         output_pool = None
 


### PR DESCRIPTION
In order to make x3d work on ANE, we have to remove any references to autograd.Function and any AdaptiveAvgPool3d. This code removes autograd.Function from Swish and AdaptiveAvgPool3d from the head of x3d.