### PR TITLE
Add sport option x3d

### DIFF
--- a/pytorchvideo/models/x3d.py
+++ b/pytorchvideo/models/x3d.py
@@ -14,6 +14,11 @@ from pytorchvideo.models.head import ResNetBasicHead
 from pytorchvideo.models.net import Net
 from pytorchvideo.models.resnet import BottleneckBlock, ResBlock, ResStage
 from pytorchvideo.models.stem import ResNetBasicStem
+from enum import Enum
+
+class X3DSport(Enum):
+    BASKETBALL = 0
+    VOLLEYBALL = 1
 
 
 def create_x3d_stem(
@@ -429,6 +434,7 @@ def create_x3d_head(
     activation: Callable = nn.ReLU,
     # Output configs.
     output_with_global_average: bool = True,
+    sport: X3DSport,
 ) -> nn.Module:
     """
     Creates X3D head. This layer performs an projected pooling operation followed
@@ -523,7 +529,10 @@ def create_x3d_head(
         )
 
     if output_with_global_average:
-        output_pool = nn.AvgPool3d(kernel_size=(4, 6, 6))
+        if sport == X3DSport.BASKETBALL:
+            output_pool = nn.AvgPool3d(kernel_size=(4, 6, 6))
+        elif sport == X3DSport.VOLLEYBALL:
+            output_pool = nn.AvgPool3d(kernel_size=(7, 7, 7))
     else:
         output_pool = None
 
@@ -576,6 +585,7 @@ def create_x3d(
     head_bn_lin5_on: bool = False,
     head_activation: Callable = nn.ReLU,
     head_output_with_global_average: bool = True,
+    sport: X3DSport = X3DSport.BASKETBALL,
 ) -> nn.Module:
     """
     X3D model builder. It builds a X3D network backbone, which is a ResNet.
@@ -734,6 +744,7 @@ def create_x3d(
         dropout_rate=dropout_rate,
         activation=head_activation,
         output_with_global_average=head_output_with_global_average,
+        sport=sport,
     )
     blocks.append(head)
     return Net(blocks=nn.ModuleList(blocks))

--- a/pytorchvideo/models/x3d.py
+++ b/pytorchvideo/models/x3d.py
@@ -532,7 +532,7 @@ def create_x3d_head(
         if sport == X3DSport.BASKETBALL:
             output_pool = nn.AvgPool3d(kernel_size=(4, 6, 6))
         elif sport == X3DSport.VOLLEYBALL:
-            output_pool = nn.AvgPool3d(kernel_size=(7, 7, 7))
+            output_pool = nn.AvgPool3d(kernel_size=(7, 12, 12))
     else:
         output_pool = None
 


### PR DESCRIPTION
Adding the ability to specify the sport in x3d to modify the AvgPool3d kernel size based on the sport. Default is basketball