### PR TITLE
changing the indices to be on the same device as x

### DIFF
--- a/pytorchvideo/transforms/functional.py
+++ b/pytorchvideo/transforms/functional.py
@@ -37,7 +37,7 @@ def uniform_temporal_subsample(
     assert num_samples > 0 and t > 0
     # Sample by nearest neighbor interpolation if num_samples > t.
     device = x.device
-    indices = torch.linspace(0, t - 1, num_samples,device=device)
+    indices = torch.linspace(0, t - 1, num_samples, device=device)
     indices = torch.clamp(indices, 0, t - 1).long()
     return torch.index_select(x, temporal_dim, indices)
 

--- a/pytorchvideo/transforms/functional.py
+++ b/pytorchvideo/transforms/functional.py
@@ -36,7 +36,8 @@ def uniform_temporal_subsample(
     t = x.shape[temporal_dim]
     assert num_samples > 0 and t > 0
     # Sample by nearest neighbor interpolation if num_samples > t.
-    indices = torch.linspace(0, t - 1, num_samples)
+    device = x.device
+    indices = torch.linspace(0, t - 1, num_samples,device=device)
     indices = torch.clamp(indices, 0, t - 1).long()
     return torch.index_select(x, temporal_dim, indices)
 


### PR DESCRIPTION
## Motivation and Context

While loading the dataset and running the model on GPU, the uniform temporal subsample was throwing an error `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! `

Upon digging, I found an existing issue:
 [Existing Issue](https://github.com/facebookresearch/pytorchvideo/issues/256)
The problem is that while running on GPU, the indices should also be on the GPU and in this case it wasn't. Hence, I am using the device parameter to move the indices to GPU.